### PR TITLE
Fixed #48 - Tried to use Example t04

### DIFF
--- a/src/test/java/org/xmlbeam/tutorial/e04_maven/TestMavenPOM.java
+++ b/src/test/java/org/xmlbeam/tutorial/e04_maven/TestMavenPOM.java
@@ -24,6 +24,8 @@ import org.junit.experimental.categories.Category;
 import org.xml.sax.SAXException;
 import org.xmlbeam.XBProjector;
 import org.xmlbeam.XBProjector.Flags;
+import org.xmlbeam.config.DefaultXMLFactoriesConfig;
+import org.xmlbeam.config.DefaultXMLFactoriesConfig.NamespacePhilosophy;
 import org.xmlbeam.tutorial.Tutorial;
 import org.xmlbeam.tutorial.TutorialTestCase;
 import org.xmlbeam.tutorial.e04_maven.MavenPOM.Artifact;
@@ -46,7 +48,13 @@ END SNIPPET: TutorialDescription */
     @Test
     public void testProjectNameWriting() throws SAXException, IOException, ParserConfigurationException {
 //START SNIPPET: TestMavenPOM
-MavenPOM pom = new XBProjector(Flags.TO_STRING_RENDERS_XML).io().fromURLAnnotation(MavenPOM.class);
+
+DefaultXMLFactoriesConfig config = new DefaultXMLFactoriesConfig();
+config.setNamespacePhilosophy(NamespacePhilosophy.AGNOSTIC);
+// This is needed to suppress the usage of name spaces.
+config.setOmitXMLDeclaration(false);
+
+MavenPOM pom = new XBProjector(config, Flags.TO_STRING_RENDERS_XML).io().fromURLAnnotation(MavenPOM.class);
 pom.setName("New name");
 for (Artifact artifact:pom.getDependencies()) {
     if (artifact.equals(pom.getProjectId())) {


### PR DESCRIPTION
 o Enhanced the given Maven example where a configuration
   is needed to suppress the usage of name spaces.
   Otherwise you have to define name spaces on the Projector.